### PR TITLE
Remove Flattr

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ smallwindow
 
  - fossfreedom <foss.freedom@gmail.com>, website - https://github.com/fossfreedom
 
-[![Flattr Button](http://api.flattr.com/button/button-compact-static-100x17.png "Flattr This!")](http://flattr.com/thing/1811689/ "fossfreedom")  [![paypaldonate](https://www.paypalobjects.com/en_GB/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=KBV682WJ3BDGL)
+[![paypaldonate](https://www.paypalobjects.com/en_GB/i/btn/btn_donate_SM.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=KBV682WJ3BDGL)
 
 -------
 


### PR DESCRIPTION
Thank you for this plugin!  It's very kind of you to have released it.

I looked at the README and... unfortunately, Flattr is no more, so I removed it.

https://flattr.com/

> 404 | Service No Longer Exists
> 
> Dear Cherished Community,
> 
> After 14 years, it's time to say goodbye to our micro-donation platform, a platform that redefined support for creatives and also embodied the spirit of ingenuity and generosity.
> 
> From our first day to this graceful finale, you've been the heart of our story. Your enthusiasm and belief in our mission transformed a simple idea into a thriving ecosystem for artists and innovators.
> 
> This year, we briefly expanded our horizons with the Anti-adblock Pass service, aspiring to further empower your digital experience. Although this chapter was short, it was driven by our unwavering commitment to serve your needs and break new ground.
> 
> As we draw the curtains on both ventures, we want to extend our deepest gratitude. Every donation you made was a testament to your faith in creativity.
> 
> Thank you for walking this path with us, for sharing our vision, and for being the cornerstone of this remarkable journey. May the future bring you endless creativity, joy, and success.
> 
> Until we meet again,
> 
> The Flattr Team